### PR TITLE
Remove `add safe` step

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -27,8 +27,6 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - name: add safe
-        run: git config --global --add safe.directory /github/workspace
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2


### PR DESCRIPTION
As CI use container to build, add safe out of the container is useless and can be removed